### PR TITLE
alias client.leave to client.part

### DIFF
--- a/library/client.js
+++ b/library/client.js
@@ -890,6 +890,8 @@ client.prototype.part = function part(channel) {
     if (this.socket !== null) { this.socket.crlfWrite('PART ' + Utils.addHash(channel).toLowerCase()); }
 };
 
+client.prototype.leave = client.prototype.part;
+
 /**
  * Send a PING to the server.
  */


### PR DESCRIPTION
#32

When searching for a method in the documentation to leave a channel. I searched through the documentation and couldn't find anything. I had to look in `client.js` to find the .part method. Aliasing this and including this in the Wiki may save users time. Eventually maybe deprecating .part.

Thoughts @Schmoopiie? 